### PR TITLE
Fix d'une exception au scroll sur un test

### DIFF
--- a/src/panel/components/DevToolsContainer.js
+++ b/src/panel/components/DevToolsContainer.js
@@ -22,9 +22,11 @@ const mergeProps = ({version, ...stateProps}, {dispatch}, ownProps) => ({
 		dispatch(setReferenceVersion(version));
 	},
 	onSearchCriterion(id) {
-		document
-			.querySelector(`.Criterion[data-id="${id}"]`)
-			.scrollIntoView(true);
+		const criterion = document.querySelector(`.Criterion[data-id="${id}"]`);
+
+		if (criterion) {
+			criterion.scrollIntoView(true);
+		}
 	}
 });
 


### PR DESCRIPTION
En utilisant la recherche rapide, une exception était lancée quand la recherche ne trouvait pas de test correspondant.