### PR TITLE
Version 1.0.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 2,
 	"name": "Assistant RGAA",
 	"description": "Assistant RGAA",
-	"version": "1.0.2",
+	"version": "1.0.4",
 	"icons": {
 		"48": "img/icon-48.png",
 		"96": "img/icon-96.png"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assistant-rgaa",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Assistant RGAA",
   "main": "js/index.js",
   "scripts": {


### PR DESCRIPTION
J'ai dû sauter la version 1.0.3 à cause d'un problème avec la signature d'extensions Mozilla.
Une build 1.0.3 avait été signée, mais n'était pas synchronisée avec l'état actuel de l'application.
Malheureusement, il est impossible de modifier une version une fois signée, je suis donc passé en 1.0.4.

Ça ne devrait pas poser de problème puisque ce numéro est tout de même valide, et qu'il n'est de toutes façons utilisé qu'à titre indicatif à l'heure actuelle (l'application n'étant pas distribuée sur npm par exemple).